### PR TITLE
fix/ modal cannot get width height if dont define style

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Add this line to `Info.plist`:
 <key>NSCameraUsageDescription</key>
 <string>YOUR TO REQUEST CAMERA PERMISSION</string>
 ```
- 
- Add to `Podfile`: 
+
+ Add to `Podfile`:
  ```
 target 'YourAwesomeProject' do
  #...
@@ -142,11 +142,11 @@ Like `npm start`, but also attempts to open your app on a connected Android devi
 │   │   ├── base
 │   │   │   ├── modal
 │   │   │   │   ├── DialogComponent.tsx
-│   │   │   │   ├── DialogManager.tsx
-│   │   │   │   └── index.tsx
+│   │   │   │   ├── ModalComponent.tsx
+│   │   │   │   ├── useLoading.tsx
+│   │   │   │   └── useModal.tsx
 │   │   │   ├── picker
 │   │   │   │   └── StyledPicker.tsx
-│   │   │   │   └── StyledPickerView.tsx
 │   │   │   ├── StyledButton.tsx
 │   │   │   ├── StyledIcon.tsx
 │   │   │   ├── StyledImage.tsx

--- a/src/components/base/modal/useModal.tsx
+++ b/src/components/base/modal/useModal.tsx
@@ -19,8 +19,8 @@ interface UseModalProps {
 
 interface ModalProps {
     children?: any;
-    width?: any;
-    height?: any;
+    modalWrapperWidth?: string | number;
+    modalWrapperHeight?: string | number;
     isFromBottom?: boolean;
     onBackdropPress?(): void;
 }
@@ -55,8 +55,8 @@ const useModal = (): UseModalProps => {
                     modalId={modalId}
                     onBackdropPressed={props.onBackdropPress}
                     isFromBottom={props.isFromBottom}
-                    height={props.height}
-                    width={props.width}
+                    modalWrapperWidth={props.modalWrapperWidth}
+                    modalWrapperHeight={props.modalWrapperHeight}
                 />
             ),
             callback,

--- a/src/feature/home/HomeScreen.tsx
+++ b/src/feature/home/HomeScreen.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { View, Button, StyleSheet } from 'react-native';
-import StyledText from 'components/base/StyledText';
 import { useNavigation } from '@react-navigation/native';
 import useModal from 'components/base/modal/useModal';
 import StyledHeader from 'components/common/StyledHeader';
@@ -8,6 +7,7 @@ import { TAB_NAVIGATION_ROOT } from 'navigation/config/routes';
 import useLoading from 'components/base/modal/useLoading';
 import { wait } from 'utilities/helper';
 import StyledPicker from 'components/base/picker/StyledPicker';
+import ModalContent from './components/ModalContent';
 
 const dataPicker = [
     'label1',
@@ -27,6 +27,7 @@ const HomeScreen: React.FunctionComponent = () => {
     const modal = useModal();
     const loading = useLoading();
     const [valuePicker, setValuePicker] = React.useState(dataPicker[0]);
+    const [currentValue, setCurrentValue] = React.useState(0);
 
     const fakeCallAPI = () => {
         loading.show();
@@ -44,7 +45,7 @@ const HomeScreen: React.FunctionComponent = () => {
             <StyledHeader title={'Home Screen'} />
             <View style={styles.contScreen}>
                 <StyledPicker
-                    label="HEHEHE" // Test label of styledPicker
+                    label="HEHEHE"
                     currentValue={valuePicker}
                     dataList={dataPicker}
                     onConfirm={handleConfirm}
@@ -53,17 +54,19 @@ const HomeScreen: React.FunctionComponent = () => {
                     title={'Modal'}
                     onPress={() => {
                         modal.show?.({
+                            // children: <View />,
                             children: (
-                                <View style={styles.contModalContent}>
-                                    <StyledText originValue={'Hello'} />
-                                    <StyledPicker
-                                        currentValue={valuePicker}
-                                        dataList={dataPicker}
-                                        onConfirm={handleConfirm}
-                                    />
-                                    <Button title={'hide'} onPress={() => modal.dismiss?.()} />
-                                </View>
+                                <ModalContent
+                                    currentValue={currentValue}
+                                    handleCallback={() => {
+                                        alert('Test callback from inside modal');
+                                    }}
+                                    handleSetValue={setCurrentValue}
+                                    closeModal={() => modal.dismiss?.()}
+                                />
                             ),
+                            modalWrapperWidth: '100%',
+                            modalWrapperHeight: 'aaa%',
                             onBackdropPress: () => {
                                 modal.dismiss?.();
                             },
@@ -96,7 +99,7 @@ const styles = StyleSheet.create({
         paddingHorizontal: 25,
     },
     contModalContent: {
-        width: '50%', // Define width and height of modal here
+        // flex: 1, // Must have flex: 1 in here
         backgroundColor: 'white',
         alignItems: 'center',
         justifyContent: 'center',

--- a/src/feature/home/components/ModalContent.tsx
+++ b/src/feature/home/components/ModalContent.tsx
@@ -1,0 +1,64 @@
+import { StyledText } from 'components/base';
+import StyledPicker from 'components/base/picker/StyledPicker';
+import React, { useState } from 'react';
+import { Button, StyleSheet, View } from 'react-native';
+
+interface ModalContentProps {
+    currentValue?: number;
+    handleCallback?(): void;
+    handleSetValue?(currentValue: number): void;
+    closeModal?(): void;
+}
+
+const ModalContent = (props: ModalContentProps) => {
+    const [currentValue, setCurrentValue] = useState(props?.currentValue || 0);
+    const dataPicker = [
+        'label1',
+        'label2',
+        'label3',
+        'label4',
+        'label5',
+        'label6',
+        'label7',
+        'label8',
+        'label9',
+        'label10',
+    ];
+    const [valuePicker, setValuePicker] = React.useState(dataPicker[0]);
+    const handleConfirm = (item: string) => {
+        setValuePicker(item);
+    };
+
+    return (
+        <View style={styles.contModalContent}>
+            <StyledText originValue={currentValue.toString()} />
+            <Button
+                title={'test alert'}
+                onPress={() => {
+                    props?.closeModal?.();
+                    props?.handleCallback?.();
+                }}
+            />
+            <StyledPicker currentValue={valuePicker} dataList={dataPicker} onConfirm={handleConfirm} />
+            <Button
+                title={'up and up'}
+                onPress={() => {
+                    setCurrentValue(currentValue + 1);
+                    props?.handleSetValue?.(currentValue + 1);
+                }}
+            />
+            <Button title={'hide'} onPress={() => props?.closeModal?.()} />
+        </View>
+    );
+};
+
+export default ModalContent;
+
+const styles = StyleSheet.create({
+    contModalContent: {
+        flex: 1, // Must have flex: 1 in here
+        backgroundColor: 'white',
+        alignItems: 'center',
+        justifyContent: 'center',
+    },
+});


### PR DESCRIPTION
#### What changed:
   - Sửa lỗi ko lấy được width height của children nếu không định nghĩa **style**
   - Thêm modalWrapperWidth và modalWrapperHeight để định nghĩa chiều rộng dài phần Wrapper
   - Phần content của modal đã có ví dụ mẫu, là component **ModalContent**
   - Phần content của modal bắt buộc phải có **`flex: 1`** để full được modal wrapper
#### Please check if the PR fulfills these requirements:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] The commit message follows our guidelines
- [x] Passed on Android
- [x] Passed on iOS
#### Free comment:
- N/A
#### Screenshoot (if task changed UI):
